### PR TITLE
Remove unicode flag from regex

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -524,7 +524,7 @@ function escapeString(str: string) {
  * Get the flags for a regexp from the options.
  */
 function flags(options?: { ignoreCase?: boolean }) {
-  return options && options.ignoreCase ? "ui" : "u";
+  return options && options.ignoreCase ? "i" : "";
 }
 
 /**


### PR DESCRIPTION
This enables the polyfill to work in engines which don't have unicode flag support for regexps